### PR TITLE
feat: 鼠标移动分割线可调整模块占比

### DIFF
--- a/remix/app/components/Danmaku/templates/Default/Default.tsx
+++ b/remix/app/components/Danmaku/templates/Default/Default.tsx
@@ -3,7 +3,7 @@ import { memo, useMemo } from "react";
 import type { FC } from "react";
 import { danmakuColor } from "~/resources/danmakuColor";
 import { nobleData } from "~/resources/nobleData";
-import { copyTextEvent, decompressDouyuExImageUrl, formatTime, isValidImageFile } from "~/utils";
+import { clickTextEvent, decompressDouyuExImageUrl, formatTime, isValidImageFile } from "~/utils";
 import { YUBA_IMAGE_HOST } from "~/resources/yubaCDN";
 
 interface IProps {
@@ -86,14 +86,14 @@ const Default: FC<IProps> = (props) => {
             {/* 头像 */}
             {props.showAvatar && <span className="item__avatar"><img className="avatar" src={`https://apic.douyucdn.cn/upload/${data.avatar}_small.jpg`} alt="" loading="lazy" /></span>}
             {/* 昵称 */}
-            <span className={clsx("item__name", {"super-name": data.isSuper})} onClick={(e) => copyTextEvent(e, data.nn)}>
+            <span className={clsx("item__name", {"super-name": data.isSuper})} onClick={(e) => clickTextEvent(e, data.nn, 'nn')}>
                 {/* VIP */}
                 {props.showVip && data.isVip && <span className="Barrage-roomVipIcon"></span>}
                 {data.nn}：
             </span>
             {/* 弹幕 */}
             <span style={props.showColor ? {color: danmakuColor[data.color]} : {}} className="item__txt">
-                {data.txt.includes(`[DouyuEx图片`) ? <span className="item__imgtxt" dangerouslySetInnerHTML={{ __html: danmakuText }}></span> : <span onClick={(e) => copyTextEvent(e, data.txt)}>{data.txt}</span>}
+                {data.txt.includes(`[DouyuEx图片`) ? <span className="item__imgtxt" dangerouslySetInnerHTML={{ __html: danmakuText }}></span> : <span onClick={(e) => clickTextEvent(e, data.txt, 'txt')}>{data.txt}</span>}
                 {data.repeatCount > 1 && <span className="item__repeat">x{data.repeatCount}</span>}
             </span>
             

--- a/remix/app/components/Danmaku/templates/Default/Default.tsx
+++ b/remix/app/components/Danmaku/templates/Default/Default.tsx
@@ -1,5 +1,6 @@
 import clsx from "clsx";
-import { memo, useMemo } from "react";
+import { memo, useMemo, useContext } from "react";
+import { OptionsContext } from "~/hooks/options.reducer";
 import type { FC } from "react";
 import { danmakuColor } from "~/resources/danmakuColor";
 import { nobleData } from "~/resources/nobleData";
@@ -62,6 +63,11 @@ const Default: FC<IProps> = (props) => {
         }
     }, [data.txt]);
 
+    const optionsContext = useContext(OptionsContext);
+    const handleClickTextEvent = (event: any, text: string, type: string) => {
+        clickTextEvent(optionsContext, event, text, type);
+    };
+
     return (
         <div className={clsx("item", {"fadeInLeft": props.showAnimation}, itemClass)}>
             {/* 等级 */}
@@ -86,14 +92,14 @@ const Default: FC<IProps> = (props) => {
             {/* 头像 */}
             {props.showAvatar && <span className="item__avatar"><img className="avatar" src={`https://apic.douyucdn.cn/upload/${data.avatar}_small.jpg`} alt="" loading="lazy" /></span>}
             {/* 昵称 */}
-            <span className={clsx("item__name", {"super-name": data.isSuper})} onClick={(e) => clickTextEvent(e, data.nn, 'nn')}>
+            <span className={clsx("item__name", {"super-name": data.isSuper})} onClick={(e) => handleClickTextEvent(e, data.nn, "nn")}>
                 {/* VIP */}
                 {props.showVip && data.isVip && <span className="Barrage-roomVipIcon"></span>}
                 {data.nn}：
             </span>
             {/* 弹幕 */}
             <span style={props.showColor ? {color: danmakuColor[data.color]} : {}} className="item__txt">
-                {data.txt.includes(`[DouyuEx图片`) ? <span className="item__imgtxt" dangerouslySetInnerHTML={{ __html: danmakuText }}></span> : <span onClick={(e) => clickTextEvent(e, data.txt, 'txt')}>{data.txt}</span>}
+                {data.txt.includes(`[DouyuEx图片`) ? <span className="item__imgtxt" dangerouslySetInnerHTML={{ __html: danmakuText }}></span> : <span onClick={(e) => handleClickTextEvent(e, data.txt, "txt")}>{data.txt}</span>}
                 {data.repeatCount > 1 && <span className="item__repeat">x{data.repeatCount}</span>}
             </span>
             

--- a/remix/app/components/Enter/templates/Default/Default.tsx
+++ b/remix/app/components/Enter/templates/Default/Default.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import type { FC } from "react";
-import { memo, useMemo } from "react";
+import { memo, useMemo, useContext } from "react";
+import { OptionsContext } from "~/hooks/options.reducer";
 import { nobleData } from "~/resources/nobleData";
 import { clickTextEvent, formatTime } from "~/utils";
 
@@ -34,6 +35,10 @@ const Default: FC<IProps> = (props) => {
         }
         return "";
     }, [props]);
+    const optionsContext = useContext(OptionsContext);
+    const handleClickTextEvent = (event: any, text: string, type: string) => {
+        clickTextEvent(optionsContext, event, text, type);
+    };
     return (
         <div className={clsx("item", {"fadeInLeft": props.showAnimation}, itemClass)}>
             {/* 等级 */}
@@ -43,7 +48,7 @@ const Default: FC<IProps> = (props) => {
             {/* 头像 */}
             {props.showAvatar && <span className="item__avatar"><img className="avatar" src={`https://apic.douyucdn.cn/upload/${data.avatar}_small.jpg`} loading="lazy" alt=""/></span>}
             {/* 昵称 */}
-            <span className="item__name" onClick={(e) => clickTextEvent(e, data.nn, 'nn')}><span>{data.nn}</span> 进入了直播间</span>
+            <span className="item__name" onClick={(e) => handleClickTextEvent(e, data.nn, "nn")}><span>{data.nn}</span> 进入了直播间</span>
             {props.showTime && <><br/><span className="item__time">{formatTime(String(data.key).split(".")[0])}</span></>}
         </div>
     )

--- a/remix/app/components/Enter/templates/Default/Default.tsx
+++ b/remix/app/components/Enter/templates/Default/Default.tsx
@@ -1,9 +1,11 @@
 import clsx from "clsx";
 import type { FC } from "react";
 import { memo, useMemo, useContext } from "react";
-import { OptionsContext } from "~/hooks/options.reducer";
+import { OPTIONS_ACTION, OptionsContext } from "~/hooks/options.reducer";
+import React from "react";
+import { Notify, Dialog,Button } from "react-vant";
 import { nobleData } from "~/resources/nobleData";
-import { clickTextEvent, formatTime } from "~/utils";
+import { copyTextEvent, formatTime } from "~/utils";
 
 interface IProps {
     // 进场数据
@@ -35,10 +37,58 @@ const Default: FC<IProps> = (props) => {
         }
         return "";
     }, [props]);
-    const optionsContext = useContext(OptionsContext);
-    const handleClickTextEvent = (event: any, text: string, type: string) => {
-        clickTextEvent(optionsContext, event, text, type);
-    };
+    
+    const { state, dispatch } = useContext(OptionsContext);
+
+    function clickNickNameEvent(event: any, text: string) {
+        event.stopPropagation && event.stopPropagation();
+        event.preventDefault && event.preventDefault();
+
+        const footerContent = React.createElement("div", { className: "clickText-button", style: { width: "100%" } },
+            React.createElement(Button.Group, { block: true, round: false, style: { width: "100%" } },
+
+                React.createElement(Button, {
+                    onClick: () => {
+                        copyTextEvent(event, text);
+                        closeDialog();
+                    }
+                }, "复制文本"),
+
+                React.createElement(Button, {
+                    onClick: () => {
+                        dispatch({ type: OPTIONS_ACTION.DANMAKU_BAN_NICKNAMES, payload: `${state.danmaku.ban.nicknames.join(" ")} ${text}` });
+                        Notify.show({ type: "success", message: `添加屏蔽昵称成功`, duration: 2000 });
+                        closeDialog();
+                    }
+                }, "屏蔽昵称"),
+
+                React.createElement(Button, {
+                    onClick: () => {
+                        dispatch({ type: OPTIONS_ACTION.DANMAKU_KEYNICKNAMES, payload: `${state.danmaku.keyNicknames.join(" ")} ${text}` });
+                        Notify.show({ type: "success", message: "添加高亮昵称成功", duration: 2000 });
+                        closeDialog();
+                    }
+                }, "高亮昵称")
+
+            )
+        );
+
+        Dialog.confirm({
+            message: text,
+            closeOnClickOverlay: true,
+            footer: footerContent
+        }).then(() => { }).catch(() => { });
+
+        const closeDialog = () => {
+            const _dialog = document.querySelector(".rv-overlay") as HTMLElement;
+            _dialog.dispatchEvent(new MouseEvent("click", {
+                bubbles: true,
+                cancelable: true,
+                view: window
+            }));
+        }
+    }
+
     return (
         <div className={clsx("item", {"fadeInLeft": props.showAnimation}, itemClass)}>
             {/* 等级 */}
@@ -48,7 +98,7 @@ const Default: FC<IProps> = (props) => {
             {/* 头像 */}
             {props.showAvatar && <span className="item__avatar"><img className="avatar" src={`https://apic.douyucdn.cn/upload/${data.avatar}_small.jpg`} loading="lazy" alt=""/></span>}
             {/* 昵称 */}
-            <span className="item__name" onClick={(e) => handleClickTextEvent(e, data.nn, "nn")}><span>{data.nn}</span> 进入了直播间</span>
+            <span className="item__name" onClick={(e) => clickNickNameEvent(e, data.nn)}><span>{data.nn}</span> 进入了直播间</span>
             {props.showTime && <><br/><span className="item__time">{formatTime(String(data.key).split(".")[0])}</span></>}
         </div>
     )

--- a/remix/app/components/Enter/templates/Default/Default.tsx
+++ b/remix/app/components/Enter/templates/Default/Default.tsx
@@ -2,7 +2,7 @@ import clsx from "clsx";
 import type { FC } from "react";
 import { memo, useMemo } from "react";
 import { nobleData } from "~/resources/nobleData";
-import { copyTextEvent, formatTime } from "~/utils";
+import { clickTextEvent, formatTime } from "~/utils";
 
 interface IProps {
     // 进场数据
@@ -43,7 +43,7 @@ const Default: FC<IProps> = (props) => {
             {/* 头像 */}
             {props.showAvatar && <span className="item__avatar"><img className="avatar" src={`https://apic.douyucdn.cn/upload/${data.avatar}_small.jpg`} loading="lazy" alt=""/></span>}
             {/* 昵称 */}
-            <span className="item__name" onClick={(e) => copyTextEvent(e, data.nn)}><span>{data.nn}</span> 进入了直播间</span>
+            <span className="item__name" onClick={(e) => clickTextEvent(e, data.nn, 'nn')}><span>{data.nn}</span> 进入了直播间</span>
             {props.showTime && <><br/><span className="item__time">{formatTime(String(data.key).split(".")[0])}</span></>}
         </div>
     )

--- a/remix/app/components/Gift/templates/Default/Default.tsx
+++ b/remix/app/components/Gift/templates/Default/Default.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 import { memo, useMemo } from "react";
 import { Button } from "react-vant";
 import { GIFT_TYPE } from "~/hooks/useWebsocket";
-import { clickTextEvent, formatTime } from "~/utils";
+import { clickTextEvent, clickGiftEvent, formatTime } from "~/utils";
 
 interface IProps {
     // 礼物数据
@@ -35,7 +35,7 @@ const Default: FC<IProps> = (props) => {
             <span className="item__gift">
                 <img className="avatar" src={giftData.pic} loading="lazy" alt=""/>
             </span>
-            <span className="item__cnt">{Number(data.gfcnt) !== 0 ? `${data.name}*${data.gfcnt}` : data.name}</span>
+            <span className="item__cnt" onClick={(e) => clickGiftEvent(e, data.name)}>{Number(data.gfcnt) !== 0 ? `${data.name}*${data.gfcnt}` : data.name}</span>
             <span className="item__name" onClick={(e) => clickTextEvent(e, data.nn, 'nn')}>{data.nn}</span>
             {Number(data.hits) >= 5 && <span className="item__hits">累计x{data.hits}</span>}
             {data.type === GIFT_TYPE.UNKNOWN ? <Button type="primary" size="mini" onClick={onClickReloadGiftData}>刷新礼物</Button> : <></>}

--- a/remix/app/components/Gift/templates/Default/Default.tsx
+++ b/remix/app/components/Gift/templates/Default/Default.tsx
@@ -1,6 +1,7 @@
 import clsx from "clsx";
 import type { FC } from "react";
-import { memo, useMemo } from "react";
+import { memo, useMemo, useContext } from "react";
+import { OptionsContext } from "~/hooks/options.reducer";
 import { Button } from "react-vant";
 import { GIFT_TYPE } from "~/hooks/useWebsocket";
 import { clickTextEvent, clickGiftEvent, formatTime } from "~/utils";
@@ -30,13 +31,20 @@ const Default: FC<IProps> = (props) => {
         e.stopPropagation();
         props.onClickReloadGiftData && props.onClickReloadGiftData();
     };
+    const optionsContext = useContext(OptionsContext);
+    const handleClickTextEvent = (event: any, text: string, type: string) => {
+        clickTextEvent(optionsContext, event, text, type);
+    };
+    const handleClickGiftEvent = (event: any, name: string) => {
+        clickGiftEvent(optionsContext, event, name);
+    };
     return (
         <div className={clsx("item", {"fadeInLeft": props.showAnimation}, itemClass)}>
             <span className="item__gift">
                 <img className="avatar" src={giftData.pic} loading="lazy" alt=""/>
             </span>
-            <span className="item__cnt" onClick={(e) => clickGiftEvent(e, data.name)}>{Number(data.gfcnt) !== 0 ? `${data.name}*${data.gfcnt}` : data.name}</span>
-            <span className="item__name" onClick={(e) => clickTextEvent(e, data.nn, 'nn')}>{data.nn}</span>
+            <span className="item__cnt" onClick={(e) => handleClickGiftEvent(e, data.name)}>{Number(data.gfcnt) !== 0 ? `${data.name}*${data.gfcnt}` : data.name}</span>
+            <span className="item__name" onClick={(e) => handleClickTextEvent(e, data.nn, "nn")}>{data.nn}</span>
             {Number(data.hits) >= 5 && <span className="item__hits">累计x{data.hits}</span>}
             {data.type === GIFT_TYPE.UNKNOWN ? <Button type="primary" size="mini" onClick={onClickReloadGiftData}>刷新礼物</Button> : <></>}
             <br/>

--- a/remix/app/components/Gift/templates/Default/Default.tsx
+++ b/remix/app/components/Gift/templates/Default/Default.tsx
@@ -3,7 +3,7 @@ import type { FC } from "react";
 import { memo, useMemo } from "react";
 import { Button } from "react-vant";
 import { GIFT_TYPE } from "~/hooks/useWebsocket";
-import { copyTextEvent, formatTime } from "~/utils";
+import { clickTextEvent, formatTime } from "~/utils";
 
 interface IProps {
     // 礼物数据
@@ -36,7 +36,7 @@ const Default: FC<IProps> = (props) => {
                 <img className="avatar" src={giftData.pic} loading="lazy" alt=""/>
             </span>
             <span className="item__cnt">{Number(data.gfcnt) !== 0 ? `${data.name}*${data.gfcnt}` : data.name}</span>
-            <span className="item__name" onClick={(e) => copyTextEvent(e, data.nn)}>{data.nn}</span>
+            <span className="item__name" onClick={(e) => clickTextEvent(e, data.nn, 'nn')}>{data.nn}</span>
             {Number(data.hits) >= 5 && <span className="item__hits">累计x{data.hits}</span>}
             {data.type === GIFT_TYPE.UNKNOWN ? <Button type="primary" size="mini" onClick={onClickReloadGiftData}>刷新礼物</Button> : <></>}
             <br/>

--- a/remix/app/components/Gift/templates/Default/Default.tsx
+++ b/remix/app/components/Gift/templates/Default/Default.tsx
@@ -1,10 +1,11 @@
 import clsx from "clsx";
 import type { FC } from "react";
 import { memo, useMemo, useContext } from "react";
-import { OptionsContext } from "~/hooks/options.reducer";
-import { Button } from "react-vant";
+import React from "react";
+import { OPTIONS_ACTION, OptionsContext } from "~/hooks/options.reducer";
+import { Notify, Dialog,Button } from "react-vant";
 import { GIFT_TYPE } from "~/hooks/useWebsocket";
-import { clickTextEvent, clickGiftEvent, formatTime } from "~/utils";
+import { copyTextEvent, formatTime } from "~/utils";
 
 interface IProps {
     // 礼物数据
@@ -31,20 +32,81 @@ const Default: FC<IProps> = (props) => {
         e.stopPropagation();
         props.onClickReloadGiftData && props.onClickReloadGiftData();
     };
-    const optionsContext = useContext(OptionsContext);
-    const handleClickTextEvent = (event: any, text: string, type: string) => {
-        clickTextEvent(optionsContext, event, text, type);
-    };
-    const handleClickGiftEvent = (event: any, name: string) => {
-        clickGiftEvent(optionsContext, event, name);
-    };
+
+    const { state, dispatch } = useContext(OptionsContext);
+
+    function clickNickNameEvent(event: any, text: string) {
+        event.stopPropagation && event.stopPropagation();
+        event.preventDefault && event.preventDefault();
+
+        const footerContent = React.createElement("div", { className: "clickText-button", style: { width: "100%" } },
+            React.createElement(Button.Group, { block: true, round: false, style: { width: "100%" } },
+
+                React.createElement(Button, {
+                    onClick: () => {
+                        copyTextEvent(event, text);
+                        closeDialog();
+                    }
+                }, "复制文本"),
+
+                React.createElement(Button, {
+                    onClick: () => {
+                        dispatch({ type: OPTIONS_ACTION.DANMAKU_BAN_NICKNAMES, payload: `${state.danmaku.ban.nicknames.join(" ")} ${text}` });
+                        Notify.show({ type: "success", message: `添加屏蔽昵称成功`, duration: 2000 });
+                        closeDialog();
+                    }
+                }, "屏蔽昵称"),
+
+                React.createElement(Button, {
+                    onClick: () => {
+                        dispatch({ type: OPTIONS_ACTION.DANMAKU_KEYNICKNAMES, payload: `${state.danmaku.keyNicknames.join(" ")} ${text}` });
+                        Notify.show({ type: "success", message: "添加高亮昵称成功", duration: 2000 });
+                        closeDialog();
+                    }
+                }, "高亮昵称")
+
+            )
+        );
+
+        Dialog.confirm({
+            message: text,
+            closeOnClickOverlay: true,
+            footer: footerContent
+        }).then(() => { }).catch(() => { });
+
+        const closeDialog = () => {
+            const _dialog = document.querySelector(".rv-overlay") as HTMLElement;
+            _dialog.dispatchEvent(new MouseEvent("click", {
+                bubbles: true,
+                cancelable: true,
+                view: window
+            }));
+        }
+    }
+    
+    function clickGiftEvent(event: any, name: string) {
+        event.stopPropagation && event.stopPropagation();
+        event.preventDefault && event.preventDefault();
+
+        Dialog.confirm({
+            title: "是否屏蔽该礼物",
+            message: name,
+            closeOnClickOverlay: true,
+            onCancel: () => { },
+            onConfirm: () => {
+                dispatch({ type: OPTIONS_ACTION.GIFT_BAN_KEYWORDS, payload: `${state.gift.ban.keywords.join(" ")} ${name}` });
+                Notify.show({ type: "success", message: "添加屏蔽礼物成功", duration: 2000 });
+            },
+        })
+    }
+
     return (
         <div className={clsx("item", {"fadeInLeft": props.showAnimation}, itemClass)}>
             <span className="item__gift">
                 <img className="avatar" src={giftData.pic} loading="lazy" alt=""/>
             </span>
-            <span className="item__cnt" onClick={(e) => handleClickGiftEvent(e, data.name)}>{Number(data.gfcnt) !== 0 ? `${data.name}*${data.gfcnt}` : data.name}</span>
-            <span className="item__name" onClick={(e) => handleClickTextEvent(e, data.nn, "nn")}>{data.nn}</span>
+            <span className="item__cnt" onClick={(e) => clickGiftEvent(e, data.name)}>{Number(data.gfcnt) !== 0 ? `${data.name}*${data.gfcnt}` : data.name}</span>
+            <span className="item__name" onClick={(e) => clickNickNameEvent(e, data.nn)}>{data.nn}</span>
             {Number(data.hits) >= 5 && <span className="item__hits">累计x{data.hits}</span>}
             {data.type === GIFT_TYPE.UNKNOWN ? <Button type="primary" size="mini" onClick={onClickReloadGiftData}>刷新礼物</Button> : <></>}
             <br/>

--- a/remix/app/components/Gift/templates/Default/styles/index.scss
+++ b/remix/app/components/Gift/templates/Default/styles/index.scss
@@ -25,6 +25,7 @@
         }
         .item__cnt {
             @include fontColor("contentColor");
+            cursor: pointer;
         }
         .item__hits {
             @include fontColor("contentColor");

--- a/remix/app/components/SplitLine/index.tsx
+++ b/remix/app/components/SplitLine/index.tsx
@@ -1,25 +1,91 @@
-import { memo } from "react";
-import type { FC } from "react";
+import React, { useState, useCallback, useContext, memo } from "react";
+import { OPTIONS_ACTION, OptionsContext } from "~/hooks/options.reducer";
 
 interface IProps {
-    order: number;
-    transparent: boolean;
-    direction: "row" | "column";
+  order: number;
+  transparent: boolean;
+  direction: "row" | "column";
 }
 
-const SplitLine: FC<IProps> = (props) => {
+const SplitLine: React.FC<IProps> = ({ order, transparent, direction }) => {
+
+  const [isDragging, setIsDragging] = useState(false);
+  const { state, dispatch } = useContext(OptionsContext);
+
+  const onMouseDown = useCallback((event: any) => {
+    event.stopPropagation && event.stopPropagation();
+    event.preventDefault && event.preventDefault();
+    setIsDragging(true);
+    document.body.style.cursor = direction === "row" ? "col-resize" : "row-resize";
+
+    const boxSizes = JSON.parse(JSON.stringify(state.size));
+    const windowLength: number = direction === "row" ? document.documentElement.clientWidth : document.documentElement.clientHeight;
+    const boxName: IOptionsSwitch = order === 2 ? state.switch[0] : order === 4 ? state.switch[1] : order === 6 ? state.switch[2] : state.switch[3];
+    const boxIndex: number = state.switch.indexOf(boxName);
+
+    const onMouseMove = (event: MouseEvent) => {
+      let _boxLength: number = direction === "row" ? event.clientX : event.clientY;
+      if (boxIndex === 1) {
+        _boxLength -= boxSizes[state.switch[0]] / 100 * windowLength + 12;
+      }
+      if (boxIndex === 2) {
+        _boxLength -= boxSizes[state.switch[0]] / 100 * windowLength + boxSizes[state.switch[1]] / 100 * windowLength + 24;
+      }
+      setOption(boxName, Math.floor(_boxLength / windowLength * 100));
+    };
+
+    const onMouseUp = () => {
+      event.stopPropagation && event.stopPropagation();
+      event.preventDefault && event.preventDefault();
+      setIsDragging(false);
+      document.body.style.cursor = "";
+      document.removeEventListener("mousemove", onMouseMove);
+      document.removeEventListener("mouseup", onMouseUp);
+    };
+
+
+    const setOption = (name: string, size: number) => {
+      switch (name) {
+        case "enter": dispatch({ type: OPTIONS_ACTION.SIZE, payload: { enter: size } }); break;
+        case "gift": dispatch({ type: OPTIONS_ACTION.SIZE, payload: { gift: size } }); break;
+        case "danmaku": dispatch({ type: OPTIONS_ACTION.SIZE, payload: { danmaku: size } }); break;
+        default: dispatch({ type: OPTIONS_ACTION.SIZE, payload: { superchat: size } });
+      }
+    }
+
+    document.addEventListener("mousemove", onMouseMove);
+    document.addEventListener("mouseup", onMouseUp);
+
+  }, [direction, state]);
+
+
+  const onClick = (event: any) => {
+    event.stopPropagation && event.stopPropagation();
+    event.preventDefault && event.preventDefault();
+  };
+
   return (
-    <div
-      className="splitline"
-      style={{
-        order: props.order,
-        width: props.direction === "row" ? "3px" : "100%",
-        height: props.direction === "row" ? "100%" : "3px",
-        ...props.transparent ? {backgroundColor: "transparent"} : {}
-      }}
-    ></div>
+    // 嵌套一层实现鼠标移入选取范围变大
+    <div style={{
+      order,
+      width: direction === "row" ? "12px" : "100%",
+      minWidth: direction === "row" ? "12px" : "100%",
+      height: direction === "row" ? "100%" : "12px",
+      minHeight: direction === "row" ? "100%" : "12px",
+      cursor: direction === "row" ? "col-resize" : "row-resize",
+      display: "flex"
+    }} onMouseDown={(e) => onMouseDown(e)} onClick={(e) => onClick(e)}>
+      <div
+        className="splitline"
+        style={{
+          order,
+          width: direction === "row" ? "3px" : "100%",
+          height: direction === "row" ? "100%" : "3px",
+          margin: direction === "row" ? "0 auto" : "auto 0",
+          ...transparent ? { backgroundColor: "transparent" } : {}
+        }}></div>
+    </div>
   );
 };
-
 
 export default memo(SplitLine);

--- a/remix/app/hooks/options.reducer.ts
+++ b/remix/app/hooks/options.reducer.ts
@@ -47,7 +47,7 @@ interface IOptionsAction {
     payload?: any;
 }
 
-export interface IOptionContext {
+export interface IOptionsContext {
     state: IOptions;
     dispatch: Dispatch<IOptionsAction>;
 }
@@ -269,7 +269,7 @@ const optionsReducer = (state: IOptions, action: IOptionsAction) => {
     }
 }
 
-const OptionContext = createContext<IOptionContext>({
+const OptionsContext = createContext<IOptionsContext>({
     state: defaultOptions,
     dispatch: () => {}
 });
@@ -278,5 +278,5 @@ export {
     OPTIONS_ACTION,
     defaultOptions,
     optionsReducer,
-    OptionContext
+    OptionsContext
 };

--- a/remix/app/routes/$rid.tsx
+++ b/remix/app/routes/$rid.tsx
@@ -78,42 +78,6 @@ interface ISuperchatSettingDialogData {
     value: string;
 }
 
-
-
-const createSetter = () => {
-    let value: any;
-    const setValue = (newValue: any) => {
-        value = newValue;
-    };
-    const getValue = () => value;
-    return { setValue, getValue };
-};
-const { setValue: setOptions, getValue: getOptions } = createSetter();
-const { setValue: setDispatchOptions, getValue: getDispatchOptions } = createSetter();
-
-export const addBanOption = (text: string, type: string) => {
-    const options = getOptions();
-    const dispatchOptions = getDispatchOptions();
-    if(type == 'nn'){
-        dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_BAN_NICKNAMES, payload: `${options.danmaku.ban.nicknames.join(" ")} ${text}` });
-    }
-    if(type == 'txt'){
-        dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_BAN_KEYWORDS, payload: `${options.danmaku.ban.keywords.join(" ")} ${text}` });
-    }
-}
-
-export const addKeyNicknames = (text: string) => {
-    const options = getOptions();
-    const dispatchOptions = getDispatchOptions();
-    dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_KEYNICKNAMES, payload: `${options.danmaku.keyNicknames.join(" ")} ${text}` });
-}
-
-export const banGiftKeyword = (name: string) => {
-    const options = getOptions();
-    const dispatchOptions = getDispatchOptions();
-    dispatchOptions({ type: OPTIONS_ACTION.GIFT_BAN_KEYWORDS, payload: `${options.gift.ban.keywords.join(" ")} ${name}` });
-}
-
 const Index = () => {
 	const { rid, allGiftData, exoptions } = useLoaderData<ILoaderProps>();
     const fetcher = useFetcher<ILoaderProps>();
@@ -128,8 +92,7 @@ const Index = () => {
         value: "",
         index: 0,
     });
-    setOptions(options);
-    setDispatchOptions(dispatchOptions);
+
     let effectTimer: NodeJS.Timeout;
 
     // 加载动画

--- a/remix/app/routes/$rid.tsx
+++ b/remix/app/routes/$rid.tsx
@@ -100,6 +100,12 @@ export const addBanOption = (text: string, type: string) => {
         dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_BAN_KEYWORDS, payload: `${options.danmaku.ban.keywords.join(" ")} ${text}` });
     }
 }
+export const addKeyNicknames = (text: string) => {
+    const options = getOptions();
+    const dispatchOptions = getDispatchOptions();
+    dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_KEYNICKNAMES, payload: `${options.danmaku.keyNicknames.join(" ")} ${text}` });
+ 
+}
 
 const Index = () => {
 	const { rid, allGiftData, exoptions } = useLoaderData<ILoaderProps>();

--- a/remix/app/routes/$rid.tsx
+++ b/remix/app/routes/$rid.tsx
@@ -78,6 +78,29 @@ interface ISuperchatSettingDialogData {
     value: string;
 }
 
+
+
+const createSetter = () => {
+    let value: any;
+    const setValue = (newValue: any) => {
+        value = newValue;
+    };
+    const getValue = () => value;
+    return { setValue, getValue };
+};
+const { setValue: setOptions, getValue: getOptions } = createSetter();
+const { setValue: setDispatchOptions, getValue: getDispatchOptions } = createSetter();
+export const addBanOption = (text: string, type: string) => {
+    const options = getOptions();
+    const dispatchOptions = getDispatchOptions();
+    if(type == 'nn'){
+        dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_BAN_NICKNAMES, payload: `${options.danmaku.ban.nicknames.join(" ")} ${text}` });
+    }
+    if(type == 'txt'){
+        dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_BAN_KEYWORDS, payload: `${options.danmaku.ban.keywords.join(" ")} ${text}` });
+    }
+}
+
 const Index = () => {
 	const { rid, allGiftData, exoptions } = useLoaderData<ILoaderProps>();
     const fetcher = useFetcher<ILoaderProps>();
@@ -92,7 +115,8 @@ const Index = () => {
         value: "",
         index: 0,
     });
-
+    setOptions(options);
+    setDispatchOptions(dispatchOptions);
     let effectTimer: NodeJS.Timeout;
 
     // 加载动画

--- a/remix/app/routes/$rid.tsx
+++ b/remix/app/routes/$rid.tsx
@@ -90,6 +90,7 @@ const createSetter = () => {
 };
 const { setValue: setOptions, getValue: getOptions } = createSetter();
 const { setValue: setDispatchOptions, getValue: getDispatchOptions } = createSetter();
+
 export const addBanOption = (text: string, type: string) => {
     const options = getOptions();
     const dispatchOptions = getDispatchOptions();
@@ -100,11 +101,17 @@ export const addBanOption = (text: string, type: string) => {
         dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_BAN_KEYWORDS, payload: `${options.danmaku.ban.keywords.join(" ")} ${text}` });
     }
 }
+
 export const addKeyNicknames = (text: string) => {
     const options = getOptions();
     const dispatchOptions = getDispatchOptions();
     dispatchOptions({ type: OPTIONS_ACTION.DANMAKU_KEYNICKNAMES, payload: `${options.danmaku.keyNicknames.join(" ")} ${text}` });
- 
+}
+
+export const banGiftKeyword = (name: string) => {
+    const options = getOptions();
+    const dispatchOptions = getDispatchOptions();
+    dispatchOptions({ type: OPTIONS_ACTION.GIFT_BAN_KEYWORDS, payload: `${options.gift.ban.keywords.join(" ")} ${name}` });
 }
 
 const Index = () => {

--- a/remix/app/routes/$rid.tsx
+++ b/remix/app/routes/$rid.tsx
@@ -16,7 +16,7 @@ import Danmaku from "~/components/Danmaku/index";
 
 import { Button, Cell, Checkbox, Collapse, Dialog, Field, Image, Popup, Radio, Slider, Switch, Tabs, Toast } from "react-vant";
 import { useImmerReducer } from "use-immer";
-import { defaultOptions, optionsReducer, OPTIONS_ACTION, OptionContext } from "~/hooks/options.reducer";
+import { defaultOptions, optionsReducer, OPTIONS_ACTION, OptionsContext } from "~/hooks/options.reducer";
 import Enter from "~/components/Enter";
 import Gift from "~/components/Gift";
 import SplitLine from "~/components/SplitLine";
@@ -312,7 +312,7 @@ const Index = () => {
 		return;
 	}
 
-    return <OptionContext.Provider value={{ state: options, dispatch: dispatchOptions }}>
+    return <OptionsContext.Provider value={{ state: options, dispatch: dispatchOptions }}>
         {
             options.showMode === "default" && options.showNobleNum &&
             <div className="noblenum" style={{left: options.align === "left" ? "auto" : "8px", right: options.align === "right" ? "auto" : "8px"}}>
@@ -565,7 +565,7 @@ const Index = () => {
                 </Tabs.TabPane>
             </Tabs>
         </Popup>
-    </OptionContext.Provider>;
+    </OptionsContext.Provider>;
 }
 
 export default Index;

--- a/remix/app/utils/index.ts
+++ b/remix/app/utils/index.ts
@@ -1,6 +1,6 @@
 import copy from "copy-to-clipboard";
-import { Notify } from "react-vant";
-
+import { Notify, Dialog } from "react-vant";
+import { addBanOption } from "~/routes/$rid";
 const LOCAL_NAME = "monitor_options";
 
 export function redirectUrl(url: string): void {
@@ -342,6 +342,30 @@ export function speakText(text: string, rate = 1) {
   }
   // 加入播放队列
   window.speechSynthesis.speak(speech)
+}
+
+export function onClickTextDialog(event: any, text: string, type: string) {
+  Dialog.confirm({
+    title: '请选择操作',
+    message: text,
+    cancelButtonText: ("复制文本"),
+    confirmButtonText: (type === 'nn' ? "屏蔽昵称" : type === 'txt' ? "屏蔽关键词" : ""),
+    cancelButtonColor: '#000000',
+    confirmButtonColor: '#000000',
+    closeOnClickOverlay: true,
+    onCancel: () => {
+      copyTextEvent(event, text);
+    }
+  }).then(() => {
+    addBanOption(text, type);
+    Notify.show({type: "success", message: `屏蔽${type === 'nn' ? "昵称" : type === 'txt' ? "关键词" : ""}成功`, duration: 2000});
+  }).catch(() => { });
+}
+
+export function clickTextEvent(event: any, text: string, type: string) {
+  event.stopPropagation && event.stopPropagation();
+  event.preventDefault && event.preventDefault();
+  onClickTextDialog(event, text, type);
 }
 
 export function copyTextEvent(event: any, text: string) {

--- a/remix/app/utils/index.ts
+++ b/remix/app/utils/index.ts
@@ -1,7 +1,7 @@
 import copy from "copy-to-clipboard";
 import React from 'react';
 import { Notify, Dialog, Button } from "react-vant";
-import { addBanOption, addKeyNicknames, banGiftKeyword } from "~/routes/$rid";
+import { OPTIONS_ACTION, IOptionsContext } from "~/hooks/options.reducer";
 const LOCAL_NAME = "monitor_options";
 
 export function redirectUrl(url: string): void {
@@ -345,37 +345,45 @@ export function speakText(text: string, rate = 1) {
   window.speechSynthesis.speak(speech)
 }
 
-export function clickTextEvent(event: any, text: string, type: string) {
+export function clickTextEvent(optionsContext: IOptionsContext, event: any, text: string, type: string) {
   event.stopPropagation && event.stopPropagation();
   event.preventDefault && event.preventDefault();
+  const { state, dispatch } = optionsContext;
 
-  const banText = (type === 'nn' ? "屏蔽昵称" : type === 'txt' ? "屏蔽关键词" : "");
+  const banText = (type === "nn" ? "屏蔽昵称" : type === "txt" ? "屏蔽关键词" : "");
 
   // 创建footer按钮组控件
-  const footerContent = React.createElement('div', { className: 'clickText-button', style: { width: '100%' } },
-    React.createElement(Button.Group, { block: true, round: false, style: { width: '100%' } },
+  const footerContent = React.createElement("div", { className: "clickText-button", style: { width: "100%" } },
+    React.createElement(Button.Group, { block: true, round: false, style: { width: "100%" } },
+
       React.createElement(Button, {
         onClick: () => {
           copyTextEvent(event, text);
           closeDialog();
         }
-      }, '复制文本'),
+      }, "复制文本"),
 
       React.createElement(Button, {
         onClick: () => {
-          addBanOption(text, type);
+          if (type == "nn") {
+            dispatch({ type: OPTIONS_ACTION.DANMAKU_BAN_NICKNAMES, payload: `${state.danmaku.ban.nicknames.join(" ")} ${text}` });
+          }
+          if (type == "txt") {
+            dispatch({ type: OPTIONS_ACTION.DANMAKU_BAN_KEYWORDS, payload: `${state.danmaku.ban.keywords.join(" ")} ${text}` });
+          }
           Notify.show({ type: "success", message: `添加${banText}成功`, duration: 2000 });
           closeDialog();
         }
       }, banText),
 
-      type == 'nn' && React.createElement(Button, {
+      type == "nn" && React.createElement(Button, {
         onClick: () => {
-          addKeyNicknames(text);
+          dispatch({ type: OPTIONS_ACTION.DANMAKU_KEYNICKNAMES, payload: `${state.danmaku.keyNicknames.join(" ")} ${text}` });
           Notify.show({ type: "success", message: "添加高亮昵称成功", duration: 2000 });
           closeDialog();
         }
-      }, '高亮昵称')
+      }, "高亮昵称")
+
     )
   );
 
@@ -386,8 +394,8 @@ export function clickTextEvent(event: any, text: string, type: string) {
   }).then(() => { }).catch(() => { });
 
   const closeDialog = () => {
-    const _dialog = document.querySelector('.rv-overlay') as HTMLElement;
-    _dialog.dispatchEvent(new MouseEvent('click', {
+    const _dialog = document.querySelector(".rv-overlay") as HTMLElement;
+    _dialog.dispatchEvent(new MouseEvent("click", {
       bubbles: true,
       cancelable: true,
       view: window
@@ -395,18 +403,19 @@ export function clickTextEvent(event: any, text: string, type: string) {
   }
 }
 
-export function clickGiftEvent(event: any, name: string) {
+export function clickGiftEvent(optionsContext: IOptionsContext, event: any, name: string) {
   event.stopPropagation && event.stopPropagation();
   event.preventDefault && event.preventDefault();
-
+  const { state, dispatch } = optionsContext;
+  
   Dialog.confirm({
-    title: '是否屏蔽该礼物',
+    title: "是否屏蔽该礼物",
     message: name,
     closeOnClickOverlay: true,
-    onCancel: () => {},
+    onCancel: () => { },
     onConfirm: () => {
-      banGiftKeyword(name);
-      Notify.show({type: "success", message: "添加屏蔽礼物成功", duration: 2000});
+      dispatch({ type: OPTIONS_ACTION.GIFT_BAN_KEYWORDS, payload: `${state.gift.ban.keywords.join(" ")} ${name}` });
+      Notify.show({ type: "success", message: "添加屏蔽礼物成功", duration: 2000 });
     },
   })
 }

--- a/remix/app/utils/index.ts
+++ b/remix/app/utils/index.ts
@@ -1,7 +1,7 @@
 import copy from "copy-to-clipboard";
 import React from 'react';
 import { Notify, Dialog, Button } from "react-vant";
-import { addBanOption, addKeyNicknames } from "~/routes/$rid";
+import { addBanOption, addKeyNicknames, banGiftKeyword } from "~/routes/$rid";
 const LOCAL_NAME = "monitor_options";
 
 export function redirectUrl(url: string): void {
@@ -346,12 +346,12 @@ export function speakText(text: string, rate = 1) {
 }
 
 export function clickTextEvent(event: any, text: string, type: string) {
-
   event.stopPropagation && event.stopPropagation();
   event.preventDefault && event.preventDefault();
 
-  const copyText = (type === 'nn' ? "屏蔽昵称" : type === 'txt' ? "屏蔽关键词" : "");
+  const banText = (type === 'nn' ? "屏蔽昵称" : type === 'txt' ? "屏蔽关键词" : "");
 
+  // 创建footer按钮组控件
   const footerContent = React.createElement('div', { className: 'clickText-button', style: { width: '100%' } },
     React.createElement(Button.Group, { block: true, round: false, style: { width: '100%' } },
       React.createElement(Button, {
@@ -364,10 +364,10 @@ export function clickTextEvent(event: any, text: string, type: string) {
       React.createElement(Button, {
         onClick: () => {
           addBanOption(text, type);
-          Notify.show({ type: "success", message: `添加${copyText}成功`, duration: 2000 });
+          Notify.show({ type: "success", message: `添加${banText}成功`, duration: 2000 });
           closeDialog();
         }
-      }, copyText),
+      }, banText),
 
       type == 'nn' && React.createElement(Button, {
         onClick: () => {
@@ -388,11 +388,27 @@ export function clickTextEvent(event: any, text: string, type: string) {
   const closeDialog = () => {
     const _dialog = document.querySelector('.rv-overlay') as HTMLElement;
     _dialog.dispatchEvent(new MouseEvent('click', {
-      bubbles: true, // 是否冒泡
-      cancelable: true, // 是否可取消
-      view: window // 事件发生的视图
+      bubbles: true,
+      cancelable: true,
+      view: window
     }));
   }
+}
+
+export function clickGiftEvent(event: any, name: string) {
+  event.stopPropagation && event.stopPropagation();
+  event.preventDefault && event.preventDefault();
+
+  Dialog.confirm({
+    title: '是否屏蔽该礼物',
+    message: name,
+    closeOnClickOverlay: true,
+    onCancel: () => {},
+    onConfirm: () => {
+      banGiftKeyword(name);
+      Notify.show({type: "success", message: "添加屏蔽礼物成功", duration: 2000});
+    },
+  })
 }
 
 

--- a/remix/app/utils/index.ts
+++ b/remix/app/utils/index.ts
@@ -1,7 +1,6 @@
 import copy from "copy-to-clipboard";
-import React from 'react';
-import { Notify, Dialog, Button } from "react-vant";
-import { OPTIONS_ACTION, IOptionsContext } from "~/hooks/options.reducer";
+import { Notify } from "react-vant";
+
 const LOCAL_NAME = "monitor_options";
 
 export function redirectUrl(url: string): void {
@@ -344,82 +343,6 @@ export function speakText(text: string, rate = 1) {
   // 加入播放队列
   window.speechSynthesis.speak(speech)
 }
-
-export function clickTextEvent(optionsContext: IOptionsContext, event: any, text: string, type: string) {
-  event.stopPropagation && event.stopPropagation();
-  event.preventDefault && event.preventDefault();
-  const { state, dispatch } = optionsContext;
-
-  const banText = (type === "nn" ? "屏蔽昵称" : type === "txt" ? "屏蔽关键词" : "");
-
-  // 创建footer按钮组控件
-  const footerContent = React.createElement("div", { className: "clickText-button", style: { width: "100%" } },
-    React.createElement(Button.Group, { block: true, round: false, style: { width: "100%" } },
-
-      React.createElement(Button, {
-        onClick: () => {
-          copyTextEvent(event, text);
-          closeDialog();
-        }
-      }, "复制文本"),
-
-      React.createElement(Button, {
-        onClick: () => {
-          if (type == "nn") {
-            dispatch({ type: OPTIONS_ACTION.DANMAKU_BAN_NICKNAMES, payload: `${state.danmaku.ban.nicknames.join(" ")} ${text}` });
-          }
-          if (type == "txt") {
-            dispatch({ type: OPTIONS_ACTION.DANMAKU_BAN_KEYWORDS, payload: `${state.danmaku.ban.keywords.join(" ")} ${text}` });
-          }
-          Notify.show({ type: "success", message: `添加${banText}成功`, duration: 2000 });
-          closeDialog();
-        }
-      }, banText),
-
-      type == "nn" && React.createElement(Button, {
-        onClick: () => {
-          dispatch({ type: OPTIONS_ACTION.DANMAKU_KEYNICKNAMES, payload: `${state.danmaku.keyNicknames.join(" ")} ${text}` });
-          Notify.show({ type: "success", message: "添加高亮昵称成功", duration: 2000 });
-          closeDialog();
-        }
-      }, "高亮昵称")
-
-    )
-  );
-
-  Dialog.confirm({
-    message: text,
-    closeOnClickOverlay: true,
-    footer: footerContent
-  }).then(() => { }).catch(() => { });
-
-  const closeDialog = () => {
-    const _dialog = document.querySelector(".rv-overlay") as HTMLElement;
-    _dialog.dispatchEvent(new MouseEvent("click", {
-      bubbles: true,
-      cancelable: true,
-      view: window
-    }));
-  }
-}
-
-export function clickGiftEvent(optionsContext: IOptionsContext, event: any, name: string) {
-  event.stopPropagation && event.stopPropagation();
-  event.preventDefault && event.preventDefault();
-  const { state, dispatch } = optionsContext;
-  
-  Dialog.confirm({
-    title: "是否屏蔽该礼物",
-    message: name,
-    closeOnClickOverlay: true,
-    onCancel: () => { },
-    onConfirm: () => {
-      dispatch({ type: OPTIONS_ACTION.GIFT_BAN_KEYWORDS, payload: `${state.gift.ban.keywords.join(" ")} ${name}` });
-      Notify.show({ type: "success", message: "添加屏蔽礼物成功", duration: 2000 });
-    },
-  })
-}
-
 
 export function copyTextEvent(event: any, text: string) {
   event.stopPropagation && event.stopPropagation();

--- a/remix/app/utils/index.ts
+++ b/remix/app/utils/index.ts
@@ -1,6 +1,7 @@
 import copy from "copy-to-clipboard";
-import { Notify, Dialog } from "react-vant";
-import { addBanOption } from "~/routes/$rid";
+import React from 'react';
+import { Notify, Dialog, Button } from "react-vant";
+import { addBanOption, addKeyNicknames } from "~/routes/$rid";
 const LOCAL_NAME = "monitor_options";
 
 export function redirectUrl(url: string): void {
@@ -344,29 +345,56 @@ export function speakText(text: string, rate = 1) {
   window.speechSynthesis.speak(speech)
 }
 
-export function onClickTextDialog(event: any, text: string, type: string) {
-  Dialog.confirm({
-    title: '请选择操作',
-    message: text,
-    cancelButtonText: ("复制文本"),
-    confirmButtonText: (type === 'nn' ? "屏蔽昵称" : type === 'txt' ? "屏蔽关键词" : ""),
-    cancelButtonColor: '#000000',
-    confirmButtonColor: '#000000',
-    closeOnClickOverlay: true,
-    onCancel: () => {
-      copyTextEvent(event, text);
-    }
-  }).then(() => {
-    addBanOption(text, type);
-    Notify.show({type: "success", message: `屏蔽${type === 'nn' ? "昵称" : type === 'txt' ? "关键词" : ""}成功`, duration: 2000});
-  }).catch(() => { });
-}
-
 export function clickTextEvent(event: any, text: string, type: string) {
+
   event.stopPropagation && event.stopPropagation();
   event.preventDefault && event.preventDefault();
-  onClickTextDialog(event, text, type);
+
+  const copyText = (type === 'nn' ? "屏蔽昵称" : type === 'txt' ? "屏蔽关键词" : "");
+
+  const footerContent = React.createElement('div', { className: 'clickText-button', style: { width: '100%' } },
+    React.createElement(Button.Group, { block: true, round: false, style: { width: '100%' } },
+      React.createElement(Button, {
+        onClick: () => {
+          copyTextEvent(event, text);
+          closeDialog();
+        }
+      }, '复制文本'),
+
+      React.createElement(Button, {
+        onClick: () => {
+          addBanOption(text, type);
+          Notify.show({ type: "success", message: `添加${copyText}成功`, duration: 2000 });
+          closeDialog();
+        }
+      }, copyText),
+
+      type == 'nn' && React.createElement(Button, {
+        onClick: () => {
+          addKeyNicknames(text);
+          Notify.show({ type: "success", message: "添加高亮昵称成功", duration: 2000 });
+          closeDialog();
+        }
+      }, '高亮昵称')
+    )
+  );
+
+  Dialog.confirm({
+    message: text,
+    closeOnClickOverlay: true,
+    footer: footerContent
+  }).then(() => { }).catch(() => { });
+
+  const closeDialog = () => {
+    const _dialog = document.querySelector('.rv-overlay') as HTMLElement;
+    _dialog.dispatchEvent(new MouseEvent('click', {
+      bubbles: true, // 是否冒泡
+      cancelable: true, // 是否可取消
+      view: window // 事件发生的视图
+    }));
+  }
 }
+
 
 export function copyTextEvent(event: any, text: string) {
   event.stopPropagation && event.stopPropagation();


### PR DESCRIPTION
# feat: 鼠标移动分割线可调整模块占比

> 新增鼠标移动分割线可以调整模块的占比，鼠标移入分割线改变鼠标样式。

1. 为兼容分割线的`onMouseDown`,`onMouseMove`,`onMouseUp`事件：


- 将`Default.tsx`文件下`onClick`事件改为`onMouseDown`。

- 将`$rid.tsx`文件下打开设置面板的`onClick={() => setIsShowOptions(true)}`事件改为`onMouseDown`。

  

2. 分割线增加伪宽度\高度为12px，实际显示区域样式**不变**（仍是3px），意在嵌套一层实现鼠标移入选取范围变大，方便鼠标点击。

  
![DouyuEX弹幕助手-Google-Chrome-2024-06-10-13-22-52](https://github.com/qianjiachun/douyu-monitor/assets/67721168/ee322edc-f10d-4ccf-95e6-e8a07149bfd8)

