### PR TITLE
feat: 增加匹配 /topic 访问地址

### DIFF
--- a/remix/app/routes/topic/$topic.tsx
+++ b/remix/app/routes/topic/$topic.tsx
@@ -1,0 +1,21 @@
+import type { LoaderFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+
+export const loader: LoaderFunction = async ({ request }) => {
+
+    // 从请求中获取 rid 参数
+    const url = new URL(request.url);
+    const rid = url.searchParams.get("rid");
+
+    // 重定向到 '/{rid}'
+    if (rid) {
+        return redirect(`/${rid}`);
+    }
+
+};
+
+export default function TopicRedirect() {
+    return (
+        <></>
+    )
+}


### PR DESCRIPTION
增加匹配斗鱼活动直播间地址 `/topic/{}?rid={}` 地址，重定向到 `/{rid}` 中。


为了在方便用户在地址栏中将 `douyu` 直接改为 `douyuex` 而跳转。

- [斗鱼跨平台弹幕助手 - 使用方法](https://github.com/qianjiachun/douyu-monitor/tree/main/remix#%E4%BD%BF%E7%94%A8%E6%96%B9%E6%B3%95)